### PR TITLE
🏥 Register page cleanup (#209)

### DIFF
--- a/components/general/input/TagSelection.jsx
+++ b/components/general/input/TagSelection.jsx
@@ -72,7 +72,7 @@ export const Tag = ({ tag, select, limitReached, selected }) => {
           : limitReached
           ? "cursor-disabled pointer-events-none"
           : "cursor-pointer"
-      } flex items-center justify-center py-2 rounded-sm uppercase font-extrabold text-[0.6rem]`}
+      } flex items-center justify-center py-2 rounded uppercase font-extrabold text-[0.6rem]`}
       onClick={() => {
         setToggled(!toggled);
         select({ tag });

--- a/components/pages/register/onboarding/components/input/OnboardingForm.jsx
+++ b/components/pages/register/onboarding/components/input/OnboardingForm.jsx
@@ -18,7 +18,7 @@ export const OnboardingForm = ({
 
   if (multipleFields) {
     return (
-      <Form className="w-full grid grid-cols-6 gap-3 items-center">
+      <Form className="w-full grid grid-cols-6 gap-3">
         {form.map((form) => {
           if (!form.custom) {
             return (
@@ -63,7 +63,7 @@ export const OnboardingForm = ({
     );
   } else {
     return (
-      <Form className="w-full grid grid-cols-6 gap-3 items-center">
+      <Form className="w-full grid grid-cols-6 gap-3">
         {form.custom ? (
           <div style={{ gridColumn: `span ${form.span}` }}>
             {form.component}

--- a/components/pages/register/onboarding/slides/SummarySlide.jsx
+++ b/components/pages/register/onboarding/slides/SummarySlide.jsx
@@ -137,7 +137,7 @@ export const Tag = ({ tag }) => {
   return (
     <span
       style={{ backgroundColor: clr }}
-      className="flex items-center justify-center py-2 rounded-sm uppercase font-extrabold text-[0.6rem] text-[#344357]"
+      className="flex items-center justify-center py-2 rounded uppercase font-extrabold text-[0.6rem] text-[#344357]"
     >
       {tag.name}
     </span>

--- a/components/pages/register/onboarding/slides/SummarySlide.jsx
+++ b/components/pages/register/onboarding/slides/SummarySlide.jsx
@@ -137,7 +137,7 @@ export const Tag = ({ tag }) => {
   return (
     <span
       style={{ backgroundColor: clr }}
-      className="flex items-center justify-center py-2 rounded uppercase font-extrabold text-[0.6rem] text-[#344357]"
+      className="flex text-center items-center justify-center py-2 rounded uppercase font-extrabold text-[0.6rem] text-[#344357]"
     >
       {tag.name}
     </span>

--- a/pages/api/auth/mail.js
+++ b/pages/api/auth/mail.js
@@ -3,7 +3,12 @@ import * as nodemailer from "nodemailer";
 // import * as sgTransport from "nodemailer-sendgrid-transport";
 const mail = async (req, res) => {
   const { email } = req.body;
-  const code = Math.floor(Math.random() * 1000000);
+  const nums = "1234567890";
+  let code = "";
+  for (let i = 6; i > 0; i--) {
+    code += nums[Math.floor(Math.random() * nums.length)];
+  }
+
   // const options = {
   //   auth: {
   //     api_user: process.env.SENDGRID_USERNAME,


### PR DESCRIPTION
# Cleanup `register` page

### Error handling on split layout inputs (`components/general/input/control/Field.jsx`)

Reference image:

<img width="529" alt="Screen Shot 2022-01-20 at 9 18 26 AM" src="https://user-images.githubusercontent.com/72945168/150389072-246d3205-c30c-4c58-8ef5-3114bd05c81c.png">

- fix error message moving input field
- fix label not being red when `error && unfocused`

### Fix tag spacing on `SummarySlide`

<img width="627" alt="Screen Shot 2022-01-20 at 9 23 49 AM" src="https://user-images.githubusercontent.com/72945168/150389904-98630cb6-76f9-44b7-a1bf-34b844a777b5.png">
 
- longer tags almost exceed tag box 
  - possible fixes 
     - evenly size tags relative to label size
     - optional padding

### Generated code isn't always 6 digits (`mail.js`)

<img width="274" alt="Screen Shot 2022-01-20 at 9 27 26 AM" src="https://user-images.githubusercontent.com/72945168/150390485-6b6edd0d-80eb-4828-acf3-944101ed27be.png">

- rewrite code generation snippet
   - current: `const code = Math.floor(Math.random() * 1000000);`