### PR TITLE
✨ Support for club finances (#242)

### DIFF
--- a/pages/api/club/create.js
+++ b/pages/api/club/create.js
@@ -22,6 +22,9 @@ export default async (req, res) => {
     officerMinimumGPA,
     percentAttendanceForOfficialMeeting,
     percentAttendanceToApproveDecision,
+    projectedRevenue,
+    projectedExpenses,
+    links,
   } = req.body;
 
   const tags = Array.from([...tagIds], (tagId) => {
@@ -42,7 +45,7 @@ export default async (req, res) => {
     { id: secretary.id },
   ];
 
-  const applicationInfo = {
+  let applicationInfo = {
     teacher: {
       connect: {
         id: teacherId,
@@ -58,7 +61,19 @@ export default async (req, res) => {
     percentAttendanceToApproveDecision: percentAttendanceToApproveDecision,
   };
 
-  const initialClub = await prisma.club.create({
+  if (projectedRevenue !== undefined) {
+    applicationInfo.projectedRevenue = {
+      create: projectedRevenue,
+    };
+  }
+
+  if (projectedExpenses !== undefined) {
+    applicationInfo.projectedExpenses = {
+      create: projectedExpenses,
+    };
+  }
+
+  let club = {
     data: {
       name: name,
       slug: name
@@ -113,7 +128,15 @@ export default async (req, res) => {
     include: {
       roles: true,
     },
-  });
+  };
+
+  if (links !== undefined) {
+    club.data.links = {
+      create: links,
+    };
+  }
+
+  const initialClub = await prisma.club.create(club);
 
   await prisma.user.update({
     where: {
@@ -192,6 +215,13 @@ export default async (req, res) => {
       id: initialClub.id,
     },
     include: {
+      applicationInfo: {
+        include: {
+          teacher: true,
+          projectedRevenue: true,
+          projectedExpenses: true,
+        },
+      },
       tags: true,
       roles: true,
       editors: true,

--- a/pages/api/club/get.js
+++ b/pages/api/club/get.js
@@ -68,6 +68,8 @@ export default async (req, res) => {
           applicationInfo: {
             include: {
               teacher: true,
+              projectedRevenue: true,
+              projectedExpenses: true,
             },
           },
           links: true,
@@ -103,6 +105,8 @@ export default async (req, res) => {
           applicationInfo: {
             include: {
               teacher: true,
+              projectedRevenue: true,
+              projectedExpenses: true,
             },
           },
           links: true,
@@ -130,6 +134,8 @@ export default async (req, res) => {
         applicationInfo: {
           include: {
             teacher: true,
+            projectedRevenue: true,
+            projectedExpenses: true,
           },
         },
         links: true,
@@ -141,6 +147,11 @@ export default async (req, res) => {
         },
         editors: true,
         roles: true,
+        invites: {
+          include: {
+            user: true,
+          },
+        },
       },
     });
 

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -17,7 +17,7 @@ model Club {
   location        String?
   approval        String?              @default("UNAPPROVED") //alternate value APPROVED
   status          String?              @default("DRAFT") //alternate values REVIEW / APPROVED
-  availability    String               @default("OPEN") //alternate value CLOSED
+  availability    String?              @default("OPEN") //alternate value CLOSED
   links           Link[]
   applicationInfo ClubApplicationInfo?
   tags            Tag[]
@@ -37,12 +37,13 @@ model Link {
 }
 
 model ClubApplicationInfo {
-  id      String @id @default(cuid())
-  teacher User   @relation(fields: [userId], references: [id])
-  userId  String
-  club    Club   @relation(fields: [clubId], references: [id])
-  clubId  String @unique
-
+  id                                  String              @id @default(cuid())
+  teacher                             User                @relation(fields: [userId], references: [id])
+  userId                              String
+  club                                Club                @relation(fields: [clubId], references: [id])
+  clubId                              String              @unique
+  projectedRevenue                    ProjectedRevenue[]
+  projectedExpenses                   ProjectedExpenses[]
   purpose                             String
   membershipRequirements              String
   dutiesOfMembers                     String
@@ -94,4 +95,22 @@ model Role {
   club   Club   @relation(fields: [clubId], references: [id])
   clubId String
   type   String @default("MEMBER") //alternate value: LEADER
+}
+
+model ProjectedRevenue {
+  id     String              @id @default(cuid())
+  club   ClubApplicationInfo @relation(fields: [clubId], references: [id])
+  clubId String
+  name   String
+  amount Float
+  date   String
+}
+
+model ProjectedExpenses {
+  id     String              @id @default(cuid())
+  club   ClubApplicationInfo @relation(fields: [clubId], references: [id])
+  clubId String
+  name   String
+  amount Float
+  date   String
 }


### PR DESCRIPTION
Addressing changes:
- modified schema to include projected revenue and projected income
- modified create function to include income + expenses
- modified get function to fetch expenses and revenue

Additional changes:
- added support to include links upon club create

closes: #242